### PR TITLE
github の ssig33/video-capture の master を fetch して merge して build するコマンドを追加したい

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/ssig33/video-capture.git"
   },
   "scripts": {
+    "pull-ssig33": "git checkout master && git fetch upstream && git merge upstream/master && npm run-script build",
     "build": "node utils/build.js",
     "start": "node utils/webserver.js",
     "prettier": "prettier --write '**/*.{js,jsx,css,html}'"


### PR DESCRIPTION
# なぜやるのか

毎回手作業で
```
git checkout master
git fetch upstream
git merge upstream/master
npm run-script build
```

ってやってるのが面倒になってきたので

`npm run-script pull-ssig33`

だけで済ませたい

# どうやるのか

`package.json`の`scripts`に以下のようなコマンドを追加

[![Screenshot from Gyazo](https://gyazo.com/80ba53744fe6fe8d438d93cca13e7819/raw)](https://gyazo.com/80ba53744fe6fe8d438d93cca13e7819)

# 動作確認

- ローカルに何か未コミットの変更がある場合はgit checkoutでエラーになって止まるのでウッカリ実行して作業途中の変更が飛ぶみたいなことは起きないことを確認済み

# 議論

[![Screenshot from Gyazo](https://gyazo.com/50dcaeed31e5b77a0c8bb7c516684a97/raw)](https://gyazo.com/50dcaeed31e5b77a0c8bb7c516684a97)

私は upstream という名前でリモートのマスターを登録しているんだけど、
この名前を全員で揃えないとダメなので相談したいです。

もしくはもっと各自の環境に依存しないような別のいい解決方法があったら教えてほしいです。